### PR TITLE
关于./src/Cell.h中rand报错的问题

### DIFF
--- a/src/Cell.h
+++ b/src/Cell.h
@@ -1,6 +1,7 @@
 #ifndef GAME_OF_LIFE_CELL_H
 #define GAME_OF_LIFE_CELL_H
 
+#include<cstdlib>
 
 class Cell {
 public:


### PR DESCRIPTION
![tim 20180729171445](https://user-images.githubusercontent.com/7782671/43364778-8bc254be-9353-11e8-8c8d-a44fec822b4d.png)

如图，在尝试构建过程中，发现会报错提示rand这个函数没有声明。
在Cell.h中引入头文件<cstdlib>后解决。

还有一些其他问题:
- CMakelists.txt中，·set(CMAKE_CXX_FLAGS "-stdlib=libc++")·命令，使用G++无法构建。经查，发现这是clang专有指令，删除后解决。查询发现，cmake可以自动设置环境。我不知删除这句是否有影响，也不太清楚是否有什么好办法解决这个问题。所以未做任何修改。
- 在暂停后使用F添加新细胞后，再使用space后，发现添加的新细胞并没有被成功添加。不知是我使用方法有问题，还是其他原因？(环境: Ubuntu 18.04 , g++ 7.3.0 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaypen/game-of-life/2)
<!-- Reviewable:end -->
